### PR TITLE
Adjust rlb test config to hit 2 nodes: localhost and 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Run following command in the terminal in order to generate traffic for rlb-stats
 ```sh
 while true; do
   curl "http://127.0.0.1:7070/api/v1/jump/test1?url=/mp3files/test_file_$(((RANDOM % 10) + 1)).mp3" >/dev/null 2>&1
-  curl "http://localhost:7070/api/v1/jump/test1?url=/mp3files/test_file_$(((RANDOM % 10) + 1)).mp3" >/dev/null 2>&1
   sleep $(((RANDOM % 10) + 1))
 done
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     - 7070:7070
 
     volumes:
-    - ./rlb-sample.yml:/srv/rlb.yml
+    - ./rlb.config.yml:/srv/rlb.yml
 
     environment:
     - CONF=/srv/rlb.yml

--- a/rlb.config.yml
+++ b/rlb.config.yml
@@ -5,6 +5,10 @@ services:
     ping: /api/v1/ping
     method: GET
     weight: 1
+  - server: http://localhost:7070
+    ping: /api/v1/ping
+    method: GET
+    weight: 1
 
 no_node:
 


### PR DESCRIPTION
This was the original intention of two curls in the Readme. Now test data would contain `localhost` and `127.0.0.1` nodes, instead of just `127.0.0.1`.