### PR TITLE
Add relative url fetch to API

### DIFF
--- a/webapp/data.js
+++ b/webapp/data.js
@@ -32,7 +32,7 @@ function sortFilesOrNodes(arr) {
 }
 
 async function fetchData(queryParams) {
-  const url = `/api/candle?from=${queryParams.from.toISOString()}&to=${queryParams.to.toISOString()}`;
+  const url = `api/candle?from=${queryParams.from.toISOString()}&to=${queryParams.to.toISOString()}`;
   try {
     const response = await fetch(url);
     if (!response.ok) {


### PR DESCRIPTION
To make http://stats.radio-t.com/rlb/ be able to fetch data from API as it runs rlb-stats in non-root location.