### PR TITLE
minimize sizes of candle in the storage

### DIFF
--- a/app/store/aggregate_test.go
+++ b/app/store/aggregate_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -12,67 +13,83 @@ var testsTable = []struct {
 	out    Candle
 	dumped bool
 }{
-	{LogRecord{
-		FromIP:   "127.0.0.1", // access to first file
-		FileName: "/rtfiles/rt_podcast561.mp3",
-		DestHost: "n6.radio-t.com",
-		Date:     time.Time{},
-	},
+	{ // 0
+		LogRecord{
+			FromIP:   "127.0.0.1", // access to first file
+			FileName: "/rtfiles/rt_podcast561.mp3",
+			DestHost: "n6.radio-t.com",
+			Date:     time.Time{},
+		},
 		Candle{}, // empty, not yet dumped
-		false},
-	{LogRecord{
-		FromIP:   "127.0.0.1", // access to second file
-		FileName: "/rtfiles/rt_podcast562.mp3",
-		DestHost: "n6.radio-t.com",
-		Date:     time.Time{},
+		false,
 	},
+
+	{ // 1
+		LogRecord{
+			FromIP:   "127.0.0.1", // access to second file
+			FileName: "/rtfiles/rt_podcast562.mp3",
+			DestHost: "n6.radio-t.com",
+			Date:     time.Time{},
+		},
 		Candle{}, // empty, not yet dumped
-		false},
-	{LogRecord{
-		FromIP:   "127.0.0.1", // access to first file, other node
-		FileName: "/rtfiles/rt_podcast561.mp3",
-		DestHost: "n7.radio-t.com",
-		Date:     time.Time{},
+		false,
 	},
+
+	{ // 2
+		LogRecord{
+			FromIP:   "127.0.0.1", // access to first file, other node
+			FileName: "/rtfiles/rt_podcast561.mp3",
+			DestHost: "n7.radio-t.com",
+			Date:     time.Time{},
+		},
 		Candle{}, // empty, not yet dumped
-		false},
-	{LogRecord{
-		FromIP:   "127.0.0.1", // access to first file, other minute
-		FileName: "/rtfiles/rt_podcast561.mp3",
-		DestHost: "n7.radio-t.com",
-		Date:     time.Time{}.Add(time.Minute),
+		false,
 	},
+
+	{ // 3
+		LogRecord{
+			FromIP:   "127.0.0.1", // access to first file, other minute
+			FileName: "/rtfiles/rt_podcast561.mp3",
+			DestHost: "n7.radio-t.com",
+			Date:     time.Time{}.Add(time.Minute),
+		},
 		Candle{ // from first 3 entries
 			Nodes: map[string]Info{
-				"n6.radio-t.com": {Volume: 2, Files: map[string]int{"/rtfiles/rt_podcast561.mp3": 1, "/rtfiles/rt_podcast562.mp3": 1}},
+				"n6.radio-t.com": {Volume: 2, Files: map[string]int{}},
 				"all":            {Volume: 2, Files: map[string]int{"/rtfiles/rt_podcast561.mp3": 1, "/rtfiles/rt_podcast562.mp3": 1}},
 			},
 			StartMinute: time.Time{},
 		},
-		true},
-	{LogRecord{
-		FromIP:   "127.0.0.1", // access in third minute, will not be flushed into resultCandle
-		FileName: "/rtfiles/rt_podcast561.mp3",
-		DestHost: "n7.radio-t.com",
-		Date:     time.Time{}.Add(time.Minute * 2),
+		true,
 	},
+
+	{ // 4
+		LogRecord{
+			FromIP:   "127.0.0.1", // access in third minute, will not be flushed into resultCandle
+			FileName: "/rtfiles/rt_podcast561.mp3",
+			DestHost: "n7.radio-t.com",
+			Date:     time.Time{}.Add(time.Minute * 2),
+		},
 		Candle{ // from 4th entry
 			Nodes: map[string]Info{
-				"n7.radio-t.com": {Volume: 1, Files: map[string]int{"/rtfiles/rt_podcast561.mp3": 1}},
+				"n7.radio-t.com": {Volume: 1, Files: map[string]int{}},
 				"all":            {Volume: 1, Files: map[string]int{"/rtfiles/rt_podcast561.mp3": 1}},
 			},
 			StartMinute: time.Time{}.Add(time.Minute),
 		},
-		true},
+		true,
+	},
 }
 
 func TestParsing(t *testing.T) {
 	parser := &Aggregator{}
 
 	// test LogRecord conversion to Candle
-	for _, testPair := range testsTable {
-		resultCandle, ok := parser.Store(testPair.in)
-		assert.EqualValues(t, testPair.out, resultCandle, "candle match with expected output")
-		assert.EqualValues(t, testPair.dumped, ok, "entry (not) dumped")
+	for i, tt := range testsTable {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			resultCandle, ok := parser.Store(tt.in)
+			assert.EqualValues(t, tt.out, resultCandle, "candle match with expected output")
+			assert.EqualValues(t, tt.dumped, ok, "entry (not) dumped")
+		})
 	}
 }

--- a/app/store/candle.go
+++ b/app/store/candle.go
@@ -46,7 +46,9 @@ func (c *Candle) Update(l LogRecord) {
 		if !ok {
 			node = NewInfo()
 		}
-		node.Files[l.FileName]++
+		if nodeName == "all" { // we keep all files in "all" node only
+			node.Files[l.FileName]++
+		}
 		node.Volume++
 		c.Nodes[nodeName] = node
 	}

--- a/app/store/candle_test.go
+++ b/app/store/candle_test.go
@@ -11,45 +11,48 @@ var logsTestsTable = []struct {
 	in  LogRecord
 	out Candle
 }{
-	{LogRecord{
-		FromIP:   "127.0.0.1",
-		FileName: "/rtfiles/rt_podcast561.mp3",
-		DestHost: "n6.radio-t.com",
-		Date:     time.Time{},
-	},
+	{
+		LogRecord{
+			FromIP:   "127.0.0.1",
+			FileName: "/rtfiles/rt_podcast561.mp3",
+			DestHost: "n6.radio-t.com",
+			Date:     time.Time{},
+		},
 		Candle{
 			Nodes: map[string]Info{
-				"n6.radio-t.com": {1, map[string]int{"/rtfiles/rt_podcast561.mp3": 1}},
+				"n6.radio-t.com": {1, map[string]int{}},
 				"all":            {1, map[string]int{"/rtfiles/rt_podcast561.mp3": 1}},
 			},
 			StartMinute: time.Time{},
 		},
 	},
-	{LogRecord{
-		FromIP:   "127.0.0.3",
-		FileName: "/rtfiles/rt_podcast562.mp3",
-		DestHost: "n7.radio-t.com",
-		Date:     time.Time{},
-	},
+	{
+		LogRecord{
+			FromIP:   "127.0.0.3",
+			FileName: "/rtfiles/rt_podcast562.mp3",
+			DestHost: "n7.radio-t.com",
+			Date:     time.Time{},
+		},
 		Candle{
 			Nodes: map[string]Info{
-				"n6.radio-t.com": {1, map[string]int{"/rtfiles/rt_podcast561.mp3": 1}},
-				"n7.radio-t.com": {1, map[string]int{"/rtfiles/rt_podcast562.mp3": 1}},
+				"n6.radio-t.com": {1, map[string]int{}},
+				"n7.radio-t.com": {1, map[string]int{}},
 				"all":            {2, map[string]int{"/rtfiles/rt_podcast561.mp3": 1, "/rtfiles/rt_podcast562.mp3": 1}},
 			},
 			StartMinute: time.Time{},
 		},
 	},
-	{LogRecord{
-		FromIP:   "127.0.0.2",
-		FileName: "/rtfiles/rt_podcast561.mp3",
-		DestHost: "n7.radio-t.com",
-		Date:     time.Time{},
-	},
+	{
+		LogRecord{
+			FromIP:   "127.0.0.2",
+			FileName: "/rtfiles/rt_podcast561.mp3",
+			DestHost: "n7.radio-t.com",
+			Date:     time.Time{},
+		},
 		Candle{
 			Nodes: map[string]Info{
-				"n6.radio-t.com": {1, map[string]int{"/rtfiles/rt_podcast561.mp3": 1}},
-				"n7.radio-t.com": {2, map[string]int{"/rtfiles/rt_podcast561.mp3": 1, "/rtfiles/rt_podcast562.mp3": 1}},
+				"n6.radio-t.com": {1, map[string]int{}},
+				"n7.radio-t.com": {2, map[string]int{}},
 				"all":            {3, map[string]int{"/rtfiles/rt_podcast561.mp3": 2, "/rtfiles/rt_podcast562.mp3": 1}},
 			},
 			StartMinute: time.Time{},


### PR DESCRIPTION
this PR drops all files details from the node-level candle and keeps it in the cumulative "all" node only

The reason - is currently the storage size is getting ridiculous as we keep detailed info about each file in each node. For rlb instances with multiple nodes, with a lot of files and high activity, each node will have all the files. In one case I have observed (`https://master.feed-master.com/rlb/api`) the size of storage became 500M just in the first week of usage. It also may contribute to the slowness described in #22 

I don't see any practical usage for file count on the node level. From what I can see the current UI doesn't care about it and all it needs about the file is in `all` node only. I don't see how and why we may even want to show files-per-node details, it doesn't make any sense and RLB doesn't operate on a file-level and distributes all the files the same way
