### PR TITLE
Make candle load cancelable

### DIFF
--- a/app/store/bolt_test.go
+++ b/app/store/bolt_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -22,7 +23,7 @@ func TestSaveAndLoadLogEntryBolt(t *testing.T) {
 	testCandle.StartMinute = time.Unix(0, 0)
 
 	assert.Nil(t, s.Save(testCandle), "saved fine")
-	savedCandle, err := s.Load(time.Unix(0, 0), time.Unix(0, 0).Add(time.Hour))
+	savedCandle, err := s.Load(context.Background(), time.Unix(0, 0), time.Unix(0, 0).Add(time.Hour))
 	assert.Nil(t, err, "key found")
 	require.NotEqual(t, []Candle{}, savedCandle, "key found")
 	assert.EqualValues(t, testCandle, savedCandle[0], "matches loaded msg")
@@ -54,7 +55,7 @@ func TestBolt_LoadStream(t *testing.T) {
 	testCandle.StartMinute = time.Unix(200, 0)
 	assert.Nil(t, s.Save(testCandle), "saved fine")
 
-	ch := s.LoadStream(time.Unix(0, 0), time.Unix(0, 0).Add(time.Hour))
+	ch := s.LoadStream(context.Background(), time.Unix(0, 0), time.Unix(0, 0).Add(time.Hour))
 	res := []Candle{}
 	for c := range ch {
 		res = append(res, c)

--- a/app/store/store.go
+++ b/app/store/store.go
@@ -1,11 +1,12 @@
 package store
 
 import (
+	"context"
 	"time"
 )
 
 // Engine defines interface to save log entries and load candles
 type Engine interface {
 	Save(candle Candle) (err error)
-	Load(periodStart, periodEnd time.Time) (result []Candle, err error)
+	Load(ctx context.Context, periodStart, periodEnd time.Time) (result []Candle, err error)
 }

--- a/app/web/aggregate.go
+++ b/app/web/aggregate.go
@@ -1,13 +1,14 @@
 package web
 
 import (
+	"context"
 	"time"
 
 	"github.com/umputun/rlb-stats/app/store"
 )
 
 // aggregateCandles takes candles from input, and aggregate them by aggInterval truncated to minutes
-func aggregateCandles(candles []store.Candle, aggInterval time.Duration) []store.Candle {
+func aggregateCandles(ctx context.Context, candles []store.Candle, aggInterval time.Duration) []store.Candle {
 	// initialize result in this way to return empty slice instead of nil for empty result
 	result := []store.Candle{}
 
@@ -28,6 +29,11 @@ func aggregateCandles(candles []store.Candle, aggInterval time.Duration) []store
 	}
 
 	for aggTime := firstDate; aggTime.Before(lastDate.Add(aggInterval)); aggTime = aggTime.Add(aggInterval) {
+		select {
+		case <-ctx.Done():
+			return result
+		default:
+		}
 		minuteCandle := store.NewCandle()
 		minuteCandle.StartMinute = aggTime
 		for _, c := range candles {

--- a/app/web/aggregate_test.go
+++ b/app/web/aggregate_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -126,10 +127,10 @@ var resultCandles = map[int][]store.Candle{
 
 func TestAggregation(t *testing.T) {
 	for i, result := range resultCandles {
-		testSlice := aggregateCandles(testCandles, time.Duration(i)*time.Minute)
+		testSlice := aggregateCandles(context.Background(), testCandles, time.Duration(i)*time.Minute)
 		assert.EqualValues(t, result, testSlice, "candle aggregate for %v minutes match with expected output", i)
 	}
 	// test less than 1 minute period which should have same output as 1 minute aggregation
-	testSlice := aggregateCandles(testCandles, time.Nanosecond)
+	testSlice := aggregateCandles(context.Background(), testCandles, time.Nanosecond)
 	assert.EqualValues(t, testCandles, testSlice, "candle aggregate for 1 nanosecond match with expected output")
 }

--- a/app/web/helpers.go
+++ b/app/web/helpers.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -8,13 +9,15 @@ import (
 )
 
 // loadCandles loads candles for given period of time aggregated by given duration
-func loadCandles(engine store.Engine, from time.Time, to time.Time, aggDuration time.Duration) ([]store.Candle, error) {
-	candles, err := engine.Load(from, to)
+func loadCandles(ctx context.Context, engine store.Engine, from time.Time, to time.Time,
+	aggDuration time.Duration) ([]store.Candle, error) {
+
+	candles, err := engine.Load(ctx, from, to)
 	if err != nil {
 		return nil, err
 	}
 	if aggDuration != time.Minute {
-		candles = aggregateCandles(candles, aggDuration)
+		candles = aggregateCandles(ctx, candles, aggDuration)
 	}
 	return candles, nil
 }

--- a/app/web/helpers_test.go
+++ b/app/web/helpers_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -15,20 +16,21 @@ import (
 func TestLoadCandles(t *testing.T) {
 	e, teardown := startupEngine(t, false)
 	defer teardown()
+	ctx := context.Background()
 
 	// load empty results
-	result, err := loadCandles(e, time.Time{}, time.Time{}.Add(time.Minute), time.Nanosecond)
+	result, err := loadCandles(ctx, e, time.Time{}, time.Time{}.Add(time.Minute), time.Nanosecond)
 	assert.Nil(t, err)
 	assert.Equal(t, []store.Candle{}, result)
 
 	// load non-empty results
-	result, err = loadCandles(e, time.Unix(0, 0), time.Unix(0, 0).Add(time.Minute), time.Nanosecond)
+	result, err = loadCandles(ctx, e, time.Unix(0, 0), time.Unix(0, 0).Add(time.Minute), time.Nanosecond)
 	assert.Nil(t, err)
 	assert.Equal(t, []store.Candle{storedCandle}, result)
 
 	badE, _ := startupEngine(t, true)
 	// load from non-existent files
-	result, err = loadCandles(badE, time.Unix(0, 0), time.Unix(0, 0).Add(time.Minute), time.Nanosecond)
+	result, err = loadCandles(ctx, badE, time.Unix(0, 0), time.Unix(0, 0).Add(time.Minute), time.Nanosecond)
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "test error")
 }
@@ -122,6 +124,6 @@ func (m MockDB) Save(candle store.Candle) error {
 	return errors.New("test error")
 }
 
-func (m MockDB) Load(periodStart, periodEnd time.Time) ([]store.Candle, error) {
+func (m MockDB) Load(ctx context.Context, periodStart, periodEnd time.Time) ([]store.Candle, error) {
 	return nil, errors.New("test error")
 }

--- a/app/web/server.go
+++ b/app/web/server.go
@@ -115,7 +115,7 @@ func (s Server) getCandle(w http.ResponseWriter, r *http.Request) {
 		aggDuration = toTime.Sub(fromTime).Truncate(time.Second) / time.Duration(i)
 	}
 
-	candles, err := loadCandles(s.Engine, fromTime, toTime, aggDuration)
+	candles, err := loadCandles(r.Context(), s.Engine, fromTime, toTime, aggDuration)
 	if err != nil {
 		sendErrorJSON(w, r, http.StatusBadRequest, err, "can't load candles")
 		return


### PR DESCRIPTION
related to #22 

In case if user started a heavy request and refreshed in the browser in the middle (I do it often due to slowness) it will make a second request in parallel with the old one nobody cares about anymore. Having just a few of them in parallel can kill the small server.

This PR propagates context from the request and cancel both bolt's extraction loop as well as aggregation loop

 