### PR TITLE
Fix golangci-lint deprecation errors, fix labels in Dockerfile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,34 +1,29 @@
 run:
   tests: false
   timeout: 5m
-  output:
-    format: github-actions
-  skip-dirs:
-    - vendor
 linters:
   enable:
   - bodyclose
   - dogsled
   - dupl
-  - gas
   - errcheck
+  - exportloopref
   - gochecknoinits
   - goconst
   - gocritic
   - gocyclo
   - gofmt
   - goimports
-  - revive
   - goprintffuncname
+  - gosec
   - gosec
   - gosimple
   - govet
   - ineffassign
   - misspell
-  - megacheck
   - nakedret
+  - revive
   - rowserrcheck
-  - exportloopref
   - staticcheck
   - stylecheck
   - typecheck
@@ -36,3 +31,6 @@ linters:
   - unparam
   - unused
   disable-all: true
+issues:
+  exclude-dirs:
+    - vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Build
 FROM umputun/baseimage:buildgo-latest as build
 
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker
-LABEL org.opencontainers.image.source="https://github.com/umputun/rlb-stats"
-
 ARG CI
 ARG GIT_BRANCH
 ARG SKIP_TEST
@@ -29,6 +26,10 @@ RUN \
 
 # Run
 FROM umputun/baseimage:app-latest
+
+LABEL org.opencontainers.image.authors="Dmitry Verkhoturov <paskal.07@gmail.com>"
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker
+LABEL org.opencontainers.image.source="https://github.com/umputun/rlb-stats"
 
 RUN apk add --update ca-certificates && update-ca-certificates
 


### PR DESCRIPTION
Previously, labels were not applied to resulting image because first image was used for copy but not as "from".