### PR TITLE
fix: make Aggregator concurrency-safe and fix dedup key collision

### DIFF
--- a/app/store/aggregate.go
+++ b/app/store/aggregate.go
@@ -1,13 +1,14 @@
 package store
 
 import (
-	"fmt"
+	"sync"
 	"time"
 )
 
 // Aggregator stores single log records into minute candles, returning candle for previous minute when
 // first log entry for new minute appears
 type Aggregator struct {
+	mu      sync.Mutex
 	entries []LogRecord // used to store entries which are not yet dumped into candles
 }
 
@@ -19,18 +20,13 @@ func (p *Aggregator) Store(entry LogRecord) (minuteCandle Candle, ok bool) {
 	entry.Date = time.Date(entry.Date.Year(), entry.Date.Month(), entry.Date.Day(), entry.Date.Hour(), entry.Date.Minute(),
 		0, 0, entry.Date.Location())
 
-	// if there are existing entries and date changed
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// if there are existing entries and date changed, all previous entries share the same minute
+	// and collapse into a single candle
 	if len(p.entries) != 0 && !entry.Date.Equal(p.entries[len(p.entries)-1].Date) {
-		// then all previous entries have same date precise to the minute and will be written to single candle
-		minuteCandle = NewCandle()
-		var deduplicate = map[string]struct{}{} // deduplicate store ip-file map
-		for _, entry := range p.entries {
-			if _, dup := deduplicate[fmt.Sprintf("%s-%s", entry.FileName, entry.FromIP)]; dup {
-				continue
-			}
-			minuteCandle.Update(entry)
-			deduplicate[fmt.Sprintf("%s-%s", entry.FileName, entry.FromIP)] = struct{}{}
-		}
+		minuteCandle = buildCandle(p.entries)
 		ok = true                 // candle is ready to be written
 		p.entries = []LogRecord{} // clean written entries
 	}
@@ -42,20 +38,37 @@ func (p *Aggregator) Store(entry LogRecord) (minuteCandle Candle, ok bool) {
 // Flush emits a candle from any buffered entries without waiting for a minute boundary.
 // returns false if no entries are buffered.
 func (p *Aggregator) Flush() (minuteCandle Candle, ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if len(p.entries) == 0 {
 		return Candle{}, false
 	}
 
-	minuteCandle = NewCandle()
-	deduplicate := map[string]struct{}{}
-	for _, entry := range p.entries {
-		key := fmt.Sprintf("%s-%s", entry.FileName, entry.FromIP)
+	minuteCandle = buildCandle(p.entries)
+	p.entries = nil
+	return minuteCandle, true
+}
+
+// fileIP identifies a unique file+ip pair for deduplication; a struct key avoids
+// the collisions a concatenated string key would allow (e.g. "a-b"+"c" vs "a"+"b-c")
+type fileIP struct {
+	file string
+	ip   string
+}
+
+// buildCandle collapses buffered entries into a single candle, counting each
+// unique file+ip pair once
+func buildCandle(entries []LogRecord) Candle {
+	minuteCandle := NewCandle()
+	deduplicate := map[fileIP]struct{}{}
+	for _, entry := range entries {
+		key := fileIP{file: entry.FileName, ip: entry.FromIP}
 		if _, dup := deduplicate[key]; dup {
 			continue
 		}
 		minuteCandle.Update(entry)
 		deduplicate[key] = struct{}{}
 	}
-	p.entries = nil
-	return minuteCandle, true
+	return minuteCandle
 }

--- a/app/store/aggregate_test.go
+++ b/app/store/aggregate_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,6 +93,32 @@ func TestParsing(t *testing.T) {
 			assert.EqualValues(t, tt.dumped, ok, "entry (not) dumped")
 		})
 	}
+}
+
+func TestAggregatorConcurrentStore(t *testing.T) {
+	// exercises concurrent Store/Flush access; fails under -race without the mutex
+	parser := &Aggregator{}
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				parser.Store(LogRecord{
+					FromIP:   "127.0.0." + strconv.Itoa(g),
+					FileName: "/rtfiles/rt_podcast" + strconv.Itoa(i) + ".mp3",
+					DestHost: "n6.radio-t.com",
+					Date:     baseTime.Add(time.Duration(i) * time.Minute),
+				})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// draining via Flush must not race with anything and should succeed while entries remain
+	_, _ = parser.Flush()
 }
 
 func TestFlush(t *testing.T) {

--- a/app/store/aggregate_test.go
+++ b/app/store/aggregate_test.go
@@ -96,7 +96,7 @@ func TestParsing(t *testing.T) {
 }
 
 func TestAggregatorConcurrentStore(t *testing.T) {
-	// exercises concurrent Store/Flush access; fails under -race without the mutex
+	// exercises concurrent Store calls on a shared Aggregator; fails under -race without the mutex
 	parser := &Aggregator{}
 	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
@@ -117,8 +117,10 @@ func TestAggregatorConcurrentStore(t *testing.T) {
 	}
 	wg.Wait()
 
-	// draining via Flush must not race with anything and should succeed while entries remain
-	_, _ = parser.Flush()
+	// the last stored entry is still buffered, so draining via Flush must emit a candle
+	candle, ok := parser.Flush()
+	assert.True(t, ok, "buffered entries remain after the stores, so Flush must emit a candle")
+	assert.NotEmpty(t, candle.Nodes)
 }
 
 func TestFlush(t *testing.T) {

--- a/app/store/aggregate_test.go
+++ b/app/store/aggregate_test.go
@@ -123,6 +123,21 @@ func TestAggregatorConcurrentStore(t *testing.T) {
 	assert.NotEmpty(t, candle.Nodes)
 }
 
+func TestBuildCandleDedupeKeyNoCollision(t *testing.T) {
+	// (file, ip) pairs that a naive "file-ip" string key would collapse into one:
+	// "a-b" + "c" and "a" + "b-c" both concatenate to "a-b-c". the struct key keeps
+	// them distinct, so both must be counted.
+	candle := buildCandle([]LogRecord{
+		{FromIP: "c", FileName: "a-b", DestHost: "n1", Date: time.Time{}},
+		{FromIP: "b-c", FileName: "a", DestHost: "n1", Date: time.Time{}},
+	})
+
+	assert.Equal(t, 2, candle.Nodes["all"].Volume, "distinct file+ip pairs must be counted separately")
+	assert.Equal(t, 1, candle.Nodes["all"].Files["a-b"])
+	assert.Equal(t, 1, candle.Nodes["all"].Files["a"])
+	assert.Equal(t, 2, candle.Nodes["n1"].Volume)
+}
+
 func TestFlush(t *testing.T) {
 	t.Run("empty aggregator", func(t *testing.T) {
 		parser := &Aggregator{}


### PR DESCRIPTION
POST `/api/insert` runs under `rest.Throttle(100)`, so concurrent handlers shared the `Aggregator.entries` slice with no synchronisation — a data race (no `sync` anywhere in the package) that could drop records or panic under load.

## Changes
- guard `Store` and `Flush` with a `sync.Mutex`
- extract the shared `buildCandle` helper, removing the dedupe loop duplicated between `Store` and `Flush`
- replace the concatenated string dedupe key (`"file-ip"`) with a struct key `fileIP{file, ip}`; the old key collapsed distinct pairs like `("a-b","c")` and `("a","b-c")` into one count
- add `TestAggregatorConcurrentStore` which fails under `-race` without the mutex

## Scope note
The mutex removes the data race. Fully-correct aggregation under *out-of-order concurrent* inserts additionally depends on merging same-minute candles on save — a minute split across partial candles is otherwise overwritten by `StartMinute` key in `Bolt.Save`. That half is fixed by the companion `fix/bolt-save-merge` PR.

Independent of the dashboard rewrite (#55); this file is untouched by that branch.