### PR TITLE
fix: merge same-minute candles on save instead of overwriting

### DIFF
--- a/app/store/bolt.go
+++ b/app/store/bolt.go
@@ -53,9 +53,12 @@ func (s *Bolt) Save(candle Candle) (err error) {
 		if existing := b.Get(key); existing != nil {
 			var prev Candle
 			if e := json.Unmarshal(existing, &prev); e != nil {
-				return e
+				// existing entry is unreadable; overwrite it rather than failing the save
+				// and losing the new candle too
+				log.Printf("[WARN] can't unmarshal stored candle for key %s, overwriting: %s", key, e)
+			} else {
+				candle = mergeCandles(prev, candle)
 			}
-			candle = mergeCandles(prev, candle)
 		}
 		jdata, jerr := json.Marshal(candle)
 		if jerr != nil {

--- a/app/store/bolt.go
+++ b/app/store/bolt.go
@@ -44,14 +44,24 @@ func (s *Bolt) Close() error {
 // keys are decimal Unix timestamps; lexicographic ordering matches numeric ordering
 // because all timestamps since 1973 are 10 digits (remains true until 2286).
 func (s *Bolt) Save(candle Candle) (err error) {
-	key := fmt.Sprintf("%d", candle.StartMinute.Unix())
+	key := fmt.Appendf(nil, "%d", candle.StartMinute.Unix())
 	err = s.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucket)
+		// merge with any candle already stored for this minute so a second write for the
+		// same StartMinute (flush-on-shutdown then restart, or a minute split across
+		// concurrent inserts) adds to it instead of overwriting and losing earlier stats
+		if existing := b.Get(key); existing != nil {
+			var prev Candle
+			if e := json.Unmarshal(existing, &prev); e != nil {
+				return e
+			}
+			candle = mergeCandles(prev, candle)
+		}
 		jdata, jerr := json.Marshal(candle)
 		if jerr != nil {
 			return jerr
 		}
-		return b.Put([]byte(key), jdata)
+		return b.Put(key, jdata)
 	})
 	if err != nil {
 		return err

--- a/app/store/bolt_test.go
+++ b/app/store/bolt_test.go
@@ -35,6 +35,49 @@ func TestSaveAndLoadLogEntryBolt(t *testing.T) {
 	assert.NotNil(t, err, "engine not created")
 }
 
+func TestBolt_SaveMergesSameMinute(t *testing.T) {
+	file, err := os.CreateTemp("/tmp/", "bolt_test.bd.")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	s, err := NewBolt(file.Name())
+	require.NoError(t, err)
+	defer s.Close()
+
+	minute := time.Unix(0, 0)
+
+	first := Candle{
+		StartMinute: minute,
+		Nodes: map[string]Info{
+			"n1":  {Volume: 2, Files: map[string]int{"a.mp3": 2}},
+			"all": {Volume: 2, Files: map[string]int{"a.mp3": 2}},
+		},
+	}
+	second := Candle{
+		StartMinute: minute,
+		Nodes: map[string]Info{
+			"n1":  {Volume: 1, Files: map[string]int{"a.mp3": 1}},
+			"n2":  {Volume: 3, Files: map[string]int{"b.mp3": 3}},
+			"all": {Volume: 4, Files: map[string]int{"a.mp3": 1, "b.mp3": 3}},
+		},
+	}
+
+	require.NoError(t, s.Save(first))
+	require.NoError(t, s.Save(second), "second write for the same minute must merge, not overwrite")
+
+	loaded, err := s.Load(context.Background(), minute, minute.Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, loaded, 1, "same minute stays a single candle")
+
+	got := loaded[0]
+	assert.Equal(t, 3, got.Nodes["n1"].Volume, "n1 volume summed across both writes")
+	assert.Equal(t, 3, got.Nodes["n1"].Files["a.mp3"])
+	assert.Equal(t, 3, got.Nodes["n2"].Volume, "node only in second write is kept")
+	assert.Equal(t, 6, got.Nodes["all"].Volume, "all volume summed")
+	assert.Equal(t, 3, got.Nodes["all"].Files["a.mp3"])
+	assert.Equal(t, 3, got.Nodes["all"].Files["b.mp3"])
+}
+
 func TestBolt_Close(t *testing.T) {
 	file, err := os.CreateTemp("/tmp/", "bolt_test.bd.")
 	require.NoError(t, err)
@@ -44,4 +87,3 @@ func TestBolt_Close(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoError(t, s.Close())
 }
-

--- a/app/store/bolt_test.go
+++ b/app/store/bolt_test.go
@@ -2,12 +2,14 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
 )
 
 func TestSaveAndLoadLogEntryBolt(t *testing.T) {
@@ -38,6 +40,7 @@ func TestSaveAndLoadLogEntryBolt(t *testing.T) {
 func TestBolt_SaveMergesSameMinute(t *testing.T) {
 	file, err := os.CreateTemp("/tmp/", "bolt_test.bd.")
 	require.NoError(t, err)
+	require.NoError(t, file.Close())
 	defer os.Remove(file.Name())
 
 	s, err := NewBolt(file.Name())
@@ -76,6 +79,36 @@ func TestBolt_SaveMergesSameMinute(t *testing.T) {
 	assert.Equal(t, 6, got.Nodes["all"].Volume, "all volume summed")
 	assert.Equal(t, 3, got.Nodes["all"].Files["a.mp3"])
 	assert.Equal(t, 3, got.Nodes["all"].Files["b.mp3"])
+}
+
+func TestBolt_SaveOverwritesCorruptEntry(t *testing.T) {
+	file, err := os.CreateTemp("/tmp/", "bolt_test.bd.")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	defer os.Remove(file.Name())
+
+	s, err := NewBolt(file.Name())
+	require.NoError(t, err)
+	defer s.Close()
+
+	minute := time.Unix(0, 0)
+	key := fmt.Appendf(nil, "%d", minute.Unix())
+
+	// plant a corrupt (non-JSON) value at the key
+	require.NoError(t, s.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucket).Put(key, []byte("not json"))
+	}))
+
+	candle := Candle{StartMinute: minute, Nodes: map[string]Info{
+		"all": {Volume: 5, Files: map[string]int{"a.mp3": 5}},
+	}}
+	// save must overwrite the unreadable entry rather than fail
+	require.NoError(t, s.Save(candle))
+
+	loaded, err := s.Load(context.Background(), minute, minute.Add(time.Hour))
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, 5, loaded[0].Nodes["all"].Volume, "corrupt entry overwritten with the new candle")
 }
 
 func TestBolt_Close(t *testing.T) {

--- a/app/store/candle.go
+++ b/app/store/candle.go
@@ -39,6 +39,35 @@ func NewCandle() (c Candle) {
 	return c
 }
 
+// mergeCandles combines the per-node volumes and file counts of base and add into a
+// single candle, keeping add's StartMinute. used to accumulate multiple writes for the
+// same minute instead of overwriting one with another.
+//
+// this runs only on the abnormal path where a minute is saved twice (flush-on-shutdown
+// then restart, or a minute split across concurrent inserts); normal operation saves
+// each minute once and never merges. counts are summed, so an ip+file pair that appears
+// in both fragments is counted more than once - accepted as a best-effort recovery,
+// since the alternative (overwrite) drops the earlier fragment entirely. exact
+// cross-fragment de-duplication would require persisting the dedup keys.
+func mergeCandles(base, add Candle) Candle {
+	merged := NewCandle()
+	merged.StartMinute = add.StartMinute
+	for _, src := range []Candle{base, add} {
+		for name, info := range src.Nodes {
+			node, ok := merged.Nodes[name]
+			if !ok {
+				node = NewInfo()
+			}
+			node.Volume += info.Volume
+			for file, count := range info.Files {
+				node.Files[file] += count
+			}
+			merged.Nodes[name] = node
+		}
+	}
+	return merged
+}
+
 // Update log destination node and add same stats to "all" node
 func (c *Candle) Update(l LogRecord) {
 	for _, nodeName := range []string{l.DestHost, "all"} {


### PR DESCRIPTION
`Bolt.Save` keys candles by `StartMinute.Unix()` and did a plain `Put`, so a second candle for the same minute **overwrote** the first.

## When this bites
The aggregator flushes a partial minute on shutdown (`main.go` flush path). If the process restarts within that same minute and receives more records for it, the restart's candle replaced the flushed one — the pre-restart stats were silently lost.

## Change
Merge the incoming candle with any candle already stored for the same key (sum per-node volumes and file counts). A new `mergeCandles` helper does this; `TestBolt_SaveMergesSameMinute` covers it.

## Known limitation (flagged in review)
Normal operation saves each minute exactly once and never merges — this path only runs on the abnormal duplicate-key case (restart mid-minute, or a minute split across concurrent inserts). Because counts are already aggregated, an `ip+file` pair appearing in *both* fragments is counted more than once. This is accepted as best-effort recovery: the alternative (the current overwrite) drops the earlier fragment entirely. Exact cross-fragment de-duplication would need persisted dedup keys.

Independent of the dashboard rewrite (#55). Note: #55 also touches `bolt.go` (adds `TimeRange`), so expect a trivial merge alongside this one.